### PR TITLE
use string mapping type

### DIFF
--- a/_createIndex.js
+++ b/_createIndex.js
@@ -31,7 +31,7 @@ module.exports = function createIndex() {
         dynamic_templates: [
           {
             string_fields: {
-              match_mapping_type: 'text',
+              match_mapping_type: 'string',
               match: '*',
 
               mapping: {


### PR DESCRIPTION
This is due to the following change in ES, which now throws an exception when using the 'text' type. https://github.com/elastic/elasticsearch/pull/22090