### PR TITLE
Fix mapper_parsing_exception

### DIFF
--- a/_createIndex.js
+++ b/_createIndex.js
@@ -31,7 +31,7 @@ module.exports = function createIndex() {
         dynamic_templates: [
           {
             string_fields: {
-              match_mapping_type: 'text',
+              match_mapping_type: 'string',
               match: '*',
 
               mapping: {


### PR DESCRIPTION
ES is now [throwing exceptions][1] when `match_mapping_type` contains
an invalid value. `text` is an invalid value, we must use `string` for
this [particular property][2]. Makelogs would get this error and stop
execution, failing to index any documents or create a template.

[1]: https://github.com/elastic/elasticsearch/pull/22090
[2]: https://github.com/elastic/elasticsearch/issues/16945