### PR TITLE
Bump elasticsearch client

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "async": "^1.4.2",
     "bluebird": "^2.10.0",
-    "elasticsearch": "^8.1.0",
+    "elasticsearch": "^12.1.3",
     "inquirer": "^0.11.1",
     "lodash": "~2.4.1",
     "moment": "^2.10.6",


### PR DESCRIPTION
Version 10+ of the client will set the content-type header for us, which will be needed in elasticsearch 6.