### PR TITLE
remove include_in_all from mapping

### DIFF
--- a/_createIndex.js
+++ b/_createIndex.js
@@ -54,8 +54,7 @@ module.exports = function createIndex() {
           },
           id: {
             type: 'integer',
-            index: 'true',
-            include_in_all: false
+            index: 'true'
           },
           clientip: {
             type: 'ip'


### PR DESCRIPTION
the `include_in_all` settings is no longer allowed. 

cf. https://github.com/elastic/elasticsearch/commit/b3c27a7fddfa6d7d6c4e17ce951ac1cc40b067d7