### PR TITLE
Bump elasticsearch client

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "async": "^1.4.2",
     "bluebird": "^2.10.0",
-    "elasticsearch": "^12.1.3",
+    "elasticsearch": "^13.0.0-beta2",
     "inquirer": "^0.11.1",
     "lodash": "~2.4.1",
     "moment": "^2.10.6",


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch-js/blob/d0423994de372fd03b681b94ac63740c4349240c/docs/changelog.asciidoc

Bumping so we get the content-type=application/x-ndjson change