### PR TITLE
Fix always prompting to delete index pattern

### DIFF
--- a/_createIndex.js
+++ b/_createIndex.js
@@ -117,7 +117,8 @@ module.exports = function createIndex() {
         name: indexTemplateName
       }),
       indices: client.indices.exists({
-        index: indexTemplate
+        index: indexTemplate,
+        allowNoIndices: false
       })
     });
   })


### PR DESCRIPTION
Currently the logstash index check will always return true, causing a prompt asking if we want to delete existing index patterns.  This is fixed by setting the allowNoIndices param to false.

See https://www.elastic.co/guide/en/elasticsearch/reference/5.4/breaking-changes-5.4.html#breaking_54_rest_changes