### PR TITLE
Add more pessimistic data

### DIFF
--- a/_randomEvent.js
+++ b/_randomEvent.js
@@ -125,7 +125,7 @@ module.exports = function RandomEvent(indexPrefix) {
   event['@message'] = event.ip + ' - - [' + dateAsIso + '] "GET ' + event.request + ' HTTP/1.1" ' +
       event.response + ' ' + event.bytes + ' "-" "' + event.agent + '"';
   event.spaces = 'this   is   a   thing    with lots of     spaces       wwwwoooooo';
-  event.xss = '<script>console.log("xss")</script>';
+  event.xss = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HgAGgwJ/lK3Q6wAAAABJRU5ErkJggg==" onload="alert(\'XSS found via img-onload!\')"><script>alert("XSS found via script-tag!")</script>';
   event.headings = [
     '<h3>' + samples.astronauts() + '</h5>',
     'http://' + samples.referrers() + '/' + samples.tags() + '/' + samples.astronauts()

--- a/_randomEvent.js
+++ b/_randomEvent.js
@@ -1,5 +1,6 @@
 var samples = require('./samples');
 var argv = require('./argv');
+var stringGenerator = require('./samples/string_generator');
 
 var eventCounter = -1;
 var count = argv.total;
@@ -142,6 +143,13 @@ module.exports = function RandomEvent(indexPrefix) {
     os: samples.randomOs(),
     ram: samples.randomRam()
   };
+
+  event.longValues = stringGenerator(Math.floor(Math.random() * 200 + 100));
+  event.longValuesWithSpaces = stringGenerator(Math.floor(Math.random() * 200 + 100), true);
+
+  var longFieldName = 'thisisaverylongfieldnamethatevendoesnotcontainanyspaces'
+    + 'whyitcouldpotentiallybreakouruiinseveralplaces';
+  event[longFieldName] = stringGenerator(Math.floor(Math.random() * 200 + 50));
 
   return event;
 };

--- a/samples/string_generator.js
+++ b/samples/string_generator.js
@@ -1,9 +1,9 @@
 module.exports = function stringGenerator (length, withSpaces) {
-	var chars = 'abcdefghijklmnopqrstuvwxyz';
-	if (withSpaces) {
-		chars += ' ';
-	}
-	return new Array(parseInt(length)).fill(0).map(function() {
-		return chars.charAt(Math.floor(Math.random() * chars.length));
-	}).join('');
+  var chars = 'abcdefghijklmnopqrstuvwxyz';
+  if (withSpaces) {
+    chars += ' ';
+  }
+  return new Array(parseInt(length)).fill(0).map(function() {
+    return chars.charAt(Math.floor(Math.random() * chars.length));
+  }).join('');
 };

--- a/samples/string_generator.js
+++ b/samples/string_generator.js
@@ -1,0 +1,9 @@
+module.exports = function stringGenerator (length, withSpaces) {
+	var chars = 'abcdefghijklmnopqrstuvwxyz';
+	if (withSpaces) {
+		chars += ' ';
+	}
+	return new Array(parseInt(length)).fill(0).map(function() {
+		return chars.charAt(Math.floor(Math.random() * chars.length));
+	}).join('');
+};


### PR DESCRIPTION
Since we use most of the time `makelogs` to generate logs during development, I think we should add a couple of more pessimistic datasets to it. So this PR adds the following things:

* Make the `xss` field a bit better, by including DOM injection XSS via `img onload` which would way more likely work than injecting `script`
* Add a field with a really long name, since we figured that breaks some parts of the UI
* Add fields with rather long string values (with and without spaces in them)