### PR TITLE
Use `_doc` instead of `doc` mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Documents look like this:
 ```json
 {
   "_index": "logstash-2014.06.17",
-  "_type": "doc",
+  "_type": "_doc",
   "_id": "706786",
   "_score": 11.412156,
   "_source": {

--- a/_createIndex.js
+++ b/_createIndex.js
@@ -26,7 +26,7 @@ module.exports = function createIndex() {
       }
     },
     mappings: {
-      doc: {
+      _doc: {
         // properties
         properties: omitFields({
           '@timestamp': {

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ client.usable
 
       // eventBuffer.push might return a promise,
       var delay = eventBuffer.push({
-        header: { _index: event.index, _type: 'doc' },
+        header: { _index: event.index, _type: '_doc' },
         body: event
       });
 


### PR DESCRIPTION
Use `_doc` instead of `doc` type mapping to match ES convention and to be forward compatible when types are removed.

Tested and it works. If you have already used `makelogs` to create `logstash-*` previously, and *do not allow makelogs to replace the indices/index templates*, there will be an error about multiple mappings: `Rejecting mapping update to [logstash-0] as the final mapping would have more than 1 type: [doc, _doc]`

Easiest solution is to just let makelogs replace the indices and corresponding templates.

