### PR TITLE
Adjust parseDays regex to allow signed days

### DIFF
--- a/argv/_parseDays.js
+++ b/argv/_parseDays.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var moment = require('moment');
 
-var customDayBoundsRE = /^\d+\/\d+$/;
+var customDayBoundsRE = /^\-?\d+\/\-?\d+$/;
 var oldDayExpressionRE = /[\-\+\,]/;
 
 module.exports = function parseDays(argv) {

--- a/argv/index.js
+++ b/argv/index.js
@@ -17,7 +17,7 @@ var optimist = require('optimist')
       alias: 'd',
       type: 'number',
       required: true,
-      describe: 'Mumber of days ± today to generate data for. Use one number or two seperated by a slash' +
+      describe: 'Number of days ± today to generate data for. Use one number or two separated by a slash' +
         ', e.g. "1/10" to go back one day, and forward 10',
       default: 1
     },
@@ -56,7 +56,7 @@ var optimist = require('optimist')
       type: 'boolean'
     },
     reset: {
-      describe: 'Clear all {prefix}-* indices and the makelogs index template before genrating',
+      describe: 'Clear all {prefix}-* indices and the makelogs index template before generating',
       type: 'boolean',
       default: null
     },
@@ -65,7 +65,7 @@ var optimist = require('optimist')
       type: 'boolean'
     },
     trace: {
-      describe: 'Log every request to elastisearch, including request bodies. BE CAREFULL',
+      describe: 'Log every request to elasticsearch, including request bodies. BE CAREFUL!',
       type: 'boolean'
     },
     omit: {


### PR DESCRIPTION
Small adjustment to regex test of the `--days` option to allow negative days.

I had a use case where I wanted to create logs between certain days in the past. After this change, I'm able to run this on July 25:
`node scripts/makelogs --days 7/-4`
to create:
`Generating 14000 events from 2018-07-18T00:00:00Z to 2018-07-21T23:59:59Z`

Also some tiny typo fixes.