### PR TITLE
Add use-strict header to all .js files

### DIFF
--- a/_client.js
+++ b/_client.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var formatUrl = require('url').format;
 var argv = require('./argv');
 var through2 = require('through2');

--- a/_confirmReset.js
+++ b/_confirmReset.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var inquirer = require('inquirer');
 
 var argv = require('./argv');

--- a/_createIndex.js
+++ b/_createIndex.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var argv = require('./argv');
 var client = require('./_client');
 var omitFields = require('./_omitFields');

--- a/_omitFields.js
+++ b/_omitFields.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var argv = require('./argv');
 
 if (!argv.omit) {

--- a/_randomEvent.js
+++ b/_randomEvent.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var samples = require('./samples');
 var argv = require('./argv');
 var stringGenerator = require('./samples/string_generator');

--- a/argv/_parseCount.js
+++ b/argv/_parseCount.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function setupCount(argv) {
   if (typeof argv.count === 'number') {
     return argv.count;

--- a/argv/_parseDays.js
+++ b/argv/_parseDays.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var moment = require('moment');
 
 var customDayBoundsRE = /^\-?\d+\/\-?\d+$/;

--- a/argv/_progress.js
+++ b/argv/_progress.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var ProgressBar = require('progress');
 
 module.exports = function (argv) {

--- a/argv/index.js
+++ b/argv/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var join = require('path').join;
 var read = require('fs').readFileSync;
 

--- a/eventBuffer/_bulkQueue.js
+++ b/eventBuffer/_bulkQueue.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var async = require('async');
 
 var argv = require('../argv');

--- a/eventBuffer/index.js
+++ b/eventBuffer/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var eventBuffer = [];
 var argv = require('../argv');
 var omitFields = require('../_omitFields');

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Notify user of updates
  */

--- a/samples/airports.js
+++ b/samples/airports.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = [
   { lat:31.95376472, lon: -89.23450472 },
   { lat:30.68586111, lon: -95.01792778 },

--- a/samples/astronauts.js
+++ b/samples/astronauts.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = [
   'Joseph M. Acaba',
   'Loren Acton',

--- a/samples/index.js
+++ b/samples/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var WeightedList = require('./weighted_list');
 var RandomList = require('./random_list');
 var RandomSample = require('./random_sample');

--- a/samples/ip_generator.js
+++ b/samples/ip_generator.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = IpGenerator;
 
 const random = (min, max) => (

--- a/samples/os.js
+++ b/samples/os.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = [
   'osx',
   'ios',

--- a/samples/ram.js
+++ b/samples/ram.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var gb = 1024 * 1024 * 1024;
 
 module.exports = [

--- a/samples/random_list.js
+++ b/samples/random_list.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @class RandomList
  */

--- a/samples/random_sample.js
+++ b/samples/random_sample.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @class RandomList
  */

--- a/samples/response_size.js
+++ b/samples/response_size.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Stochator = require('./stochator');
 var roundAllGets = require('./round_all_gets');
 

--- a/samples/round_all_gets.js
+++ b/samples/round_all_gets.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function (stoch) {
   var origGet = stoch.get;
   stoch.get = function () {

--- a/samples/string_generator.js
+++ b/samples/string_generator.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function stringGenerator (length, withSpaces) {
   var chars = 'abcdefghijklmnopqrstuvwxyz';
   if (withSpaces) {

--- a/samples/weighted_list.js
+++ b/samples/weighted_list.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @class WeightedList
  * @constructor


### PR DESCRIPTION
I hope you don't mind I added this 😅 It's not a requirement in Kibana because we use Babel to transpile our code which adds it for us, but this module is published to npm as-is, and as such should use this header for best practice.

I left the file `samples/stochator.js` as is as it seems like an autogenerated file that you pulled from somewhere else.