### PR TITLE
Fix --reset flag parsing

### DIFF
--- a/_confirmReset.js
+++ b/_confirmReset.js
@@ -1,10 +1,6 @@
 var inquirer = require('inquirer');
 
-var argv = require('./argv');
-
-module.exports = async function () {
-  if (argv.reset != null) return resolve();
-
+module.exports = async function (argv) {
   const resp = await inquirer.prompt([
     {
       type: 'confirm',

--- a/_createIndex.js
+++ b/_createIndex.js
@@ -136,7 +136,7 @@ module.exports = function createIndex() {
         }
         return; // do nothing, index template exists
       default:
-        return confirmReset().then(maybeReset);
+        return confirmReset(argv).then(maybeReset);
       }
     }
 

--- a/argv/index.js
+++ b/argv/index.js
@@ -93,6 +93,12 @@ if (argv.help) {
   process.exit();
 }
 
+// Possible states of `argv.reset`:
+//   default: null
+//   --reset: [null, true]
+//   --no-reset: [null, false]
+if (Array.isArray(argv.reset)) argv.reset = argv.reset.pop();
+
 switch (argv.indexInterval) {
   case 'daily':
   case 'weekly':


### PR DESCRIPTION
No matter if you used the `--reset` or the `--no-reset` flag, it would always prompt as `optimist` doesn't handle mixing a boolean flag with a non-boolean default value very well