### PR TITLE
don't use wildcard in delete, fix pfx error

### DIFF
--- a/_client.js
+++ b/_client.js
@@ -40,7 +40,7 @@ var client = module.exports = new Client({
     })
   },
   host: url,
-  ssl:{ rejectUnauthorized: false, pfx: [] }
+  ssl: argv.insecure ? { rejectUnauthorized: false, pfx: [] } : {}
 });
 
 client.usable = usable;

--- a/_client.js
+++ b/_client.js
@@ -39,7 +39,8 @@ var client = module.exports = new Client({
       });
     })
   },
-  host: url
+  host: url,
+  ssl:{ rejectUnauthorized: false, pfx: [] }
 });
 
 client.usable = usable;

--- a/_createIndex.js
+++ b/_createIndex.js
@@ -7,7 +7,7 @@ var confirmReset = require('./_confirmReset');
 var argv = require('./argv');
 
 module.exports = function createIndex() {
-  var indexTemplate = argv.indexPrefix + '*';
+  var indexTemplate = argv.indexPrefix + '0';
   var indexTemplateName = 'makelogs_index_template__' + argv.indexPrefix;
 
   var body = {

--- a/_createIndex.js
+++ b/_createIndex.js
@@ -7,7 +7,7 @@ var confirmReset = require('./_confirmReset');
 var argv = require('./argv');
 
 module.exports = function createIndex() {
-  var indexTemplate = argv.indexPrefix + '0';
+  var indexTemplate = argv.indexPrefix + '*';
   var indexTemplateName = 'makelogs_index_template__' + argv.indexPrefix;
 
   var body = {
@@ -110,18 +110,23 @@ module.exports = function createIndex() {
       allowNoIndices: false
     })
   }))
-  .then(function (exists) {
-    function clearExisting() {
+  .then(async function (exists) {
+    async function clearExisting() {
       console.log('clearing existing "%s" index templates and indices', indexTemplate);
+      const existingIndicesRsp = await client.indices.getAlias({index: indexTemplate, ignore: 404});
+      const existingIndices = Object.keys(existingIndicesRsp || {});
       return Promise.all([
         client.indices.deleteTemplate({
           ignore: 404,
           name: indexTemplateName
         }),
-        client.indices.delete({
-          ignore: 404,
-          index: indexTemplate
-        })
+        ...existingIndices.map(indexName => {
+          console.log(`deleting ${indexName}`);
+          return client.indices.delete({
+            ignore: 404,
+            index: indexName
+          })
+        }) 
       ]);
     }
 

--- a/argv/index.js
+++ b/argv/index.js
@@ -24,6 +24,7 @@ program
   .option('-i, --indexInterval <...>', 'The interval that indices should roll over, either "daily", "monthly", "yearly", or a number of documents.', parseIndexInterval, 100000)
   .option('--types', 'Pass to enable types in index and document creation')
   .option('--indexTemplatesV1', 'Pass to enable types in index templates v1 compatibility')
+  .option('--insecure', 'Pass to set ssl:{ rejectUnauthorized: false, pfx: [] }')
   .version(require('../package.json').version)
   .helpOption('--help', 'This help message')
   .on('--help', function () {


### PR DESCRIPTION
Fix for 2 issues;
1. Node 16 seems to need the change `ssl:{ rejectUnauthorized: false, pfx: [] }` when making the client connection to Elasticsearch configured with TLS and a self-signed certificate.
2. Elasticsearch 8.0 default setting doesn't allow wildcards on the index delete.  We seem to create logstash-0 by default so I changed the index template from `*` to `0`.

UPDATE: for 1 above, I added a `--insecure` option which sets `ssl:{ rejectUnauthorized: false, pfx: [] }`
and for 2 above, I changed it to iterate through any matching indices and delete each one instead of the wildcard delete.


Error on the PFX issue (I also tried setting `NODE_TLS_REJECT_UNAUTHORIZED=0` and pointing to my cluster certs with `NODE_EXTRA_CA_CERTS=` but didn't resolve);
```
node scripts/makelogs.js --url=https://elastic:changeit@localhost:9200
node:internal/tls/secure-context:278
      context.loadPKCS12(toBuf(pfx));
              ^

Error: Unable to load PFX certificate
    at configSecureContext (node:internal/tls/secure-context:278:15)
    at Object.createSecureContext (node:_tls_common:116:3)
    at Object.connect (node:_tls_wrap:1621:48)
    at HttpsAgent.createConnection (node:https:143:22)
    at HttpsAgent.createSocket (/Users/leedr/git/master/kibana/node_modules/agentkeepalive/lib/_http_agent.js:265:26)
    at HttpsAgent.createSocket (/Users/leedr/git/master/kibana/node_modules/agentkeepalive/lib/agent.js:77:11)
    at HttpsAgent.addRequest (/Users/leedr/git/master/kibana/node_modules/agentkeepalive/lib/_http_agent.js:239:10)
    at new ClientRequest (node:_http_client:305:16)
    at Object.request (node:https:353:10)
    at HttpConnector.request (/Users/leedr/git/master/kibana/node_modules/elasticsearch/src/lib/connectors/http.js:182:23) {
  code: 'ERR_CRYPTO_OPERATION_FAILED'
}
```

Notes on the wildcard delete;
https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html#delete-index-api-path-params

Now that I created this PR, I'm thinking it might be best to have 2 separate PRs.  The node 16 pfx issue will impact 8.0 and 7.16, but the delete index change only impacts 8.0 (but would work on 7.16 too).
