### PR TITLE
Dockerize makelogs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.dockerignore
+.gitignore
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+ARG NODE_VERSION=16.13.0
+FROM node:${NODE_VERSION} AS base
+
+COPY / /app
+WORKDIR /app
+RUN yarn install
+
+ENTRYPOINT [ "/app/bin/makelogs" ]


### PR DESCRIPTION
👋 , I am considering using `makelogs` for an Elastic-internal project. The project doesn't plan to run Node.js so it would be nice if `makelogs` was Dockerized. This PR takes a stab at that. 

A follow up might be using GitHub Actions to build a new Docker image for `makelogs` upon every release and publish it as a GitHub Package to ghcr.io (or alternatively Docker Hub or the Elastic Docker Registry but I suspect we don't want to "pollute" those registries with something that's not maintained as stringently as other Elastic images in those registries?).  Anyway, that's food for future thought - for now the scope of this PR is merely to introduce the ability to Dockerize `makelogs`.