### PR TITLE
custom release to span documents over days/hours/minutes

### DIFF
--- a/_client.js
+++ b/_client.js
@@ -10,6 +10,7 @@ var NoConnections = elasticsearch.errors.NoConnections;
 var RequestTimeout = elasticsearch.errors.RequestTimeout;
 
 var url = argv.url;
+console.log(url);
 if (!url) {
   var host = String(argv.host);
   var proto = host.includes('//') ? '' : '//';

--- a/_randomEvent.js
+++ b/_randomEvent.js
@@ -14,15 +14,16 @@ var countOfDays = (function () {
 
   if (cursor.valueOf() <= end) {
     do {
-      cursor.add(1, 'day');
+      cursor.add(1, argv.timeWindowType);
       count += 1;
     } while (cursor.valueOf() <= end);
   }
 
   return count;
 }());
-var countPerDay = Math.ceil(count / countOfDays);
 
+var countPerDay = Math.ceil(count / countOfDays);
+// console.log('Count', count, 'countOfDays', countOfDays, 'countPerDay', countPerDay);
 var indexInterval = argv.indexInterval;
 var dayMoment = argv.start.clone();
 var day;
@@ -32,38 +33,82 @@ module.exports = function RandomEvent(indexPrefix) {
 
   var i = ++eventCounter;
   var iInDay = i % countPerDay;
+  var ms = samples.lessRandomMsInDay();
 
   if (day && iInDay === 0) {
-    dayMoment.add(1, 'day');
+    dayMoment.add(1, argv.timeWindowType);
     day = null;
   }
 
-  if (day == null) {
-    day = {
-      year: dayMoment.year(),
-      month: dayMoment.month(),
-      date: dayMoment.date(),
-    };
+  if (argv.timeWindowType === "day") {
+    if (day == null) {
+      day = {
+        year: dayMoment.year(),
+        month: dayMoment.month(),
+        date: dayMoment.date(),
+      };
+    }
+    // extract number of hours from the milliseconds
+    var hours = Math.floor(ms / 3600000);
+    ms = ms - hours * 3600000;
+    // extract number of minutes from the milliseconds
+    var minutes = Math.floor(ms / 60000);
+    ms = ms - minutes * 60000;
+
+    // extract number of seconds from the milliseconds
+    var seconds = Math.floor(ms / 1000);
+    ms = ms - seconds * 1000;
+    // apply the values found to the date
+    var date = new Date(day.year, day.month, day.date, hours, minutes, seconds, ms);
+  }
+  else if (argv.timeWindowType === "hour") {
+    if (day == null) {
+      day = {
+        year: dayMoment.year(),
+        month: dayMoment.month(),
+        date: dayMoment.date(),
+        hour: dayMoment.hour(),
+      };
+    }
+    // extract number of hours from the milliseconds
+    var hours = Math.floor(ms / 3600000);
+    ms = ms - hours * 3600000;
+    // extract number of minutes from the milliseconds
+    var minutes = Math.floor(ms / 60000);
+    ms = ms - minutes * 60000;
+    // extract number of seconds from the milliseconds
+    var seconds = Math.floor(ms / 1000);
+    ms = ms - seconds * 1000;
+    // apply the values found to the date
+    var date = new Date(day.year, day.month, day.date, day.hour, minutes, seconds, ms);
+  }
+  else {
+    if (day == null) {
+      day = {
+        year: dayMoment.year(),
+        month: dayMoment.month(),
+        date: dayMoment.date(),
+        hour: dayMoment.hour(),
+        minute: dayMoment.minute(),
+      };
+    }
+    // extract number of hours from the milliseconds
+    var hours = Math.floor(ms / 3600000);
+    ms = ms - hours * 3600000;
+    // extract number of minutes from the milliseconds
+    var minutes = Math.floor(ms / 60000);
+    ms = ms - minutes * 60000;
+    // extract number of seconds from the milliseconds
+    var seconds = Math.floor(ms / 1000);
+    ms = ms - seconds * 1000;
+    // apply the values found to the date
+    var date = new Date(day.year, day.month, day.date, day.hour, day.minute, seconds, ms);   
   }
 
-  var ms = samples.lessRandomMsInDay();
-
-  // extract number of hours from the milliseconds
-  var hours = Math.floor(ms / 3600000);
-  ms = ms - hours * 3600000;
-
-  // extract number of minutes from the milliseconds
-  var minutes = Math.floor(ms / 60000);
-  ms = ms - minutes * 60000;
-
-  // extract number of seconds from the milliseconds
-  var seconds = Math.floor(ms / 1000);
-  ms = ms - seconds * 1000;
-
-  // apply the values found to the date
-  var date = new Date(day.year, day.month, day.date, hours, minutes, seconds, ms);
+  // console.log('i', i, 'iInDay', iInDay, 'day', day, 'date', date);
+ 
   var dateAsIso = date.toISOString();
-
+  // console.log('dateAsIso', dateAsIso, 'date', date);
   switch (indexInterval) {
     case 'yearly':
       event.index = indexPrefix + dateAsIso.substr(0, 4);

--- a/argv/_parseTime.js
+++ b/argv/_parseTime.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var moment = require('moment');
+
+var customDayBoundsRE = /^\-?\d+\/\-?\d+$/;
+var oldDayExpressionRE = /[\-\+\,]/;
+
+module.exports = function parseDays(argv) {
+  var startBase = moment().utc().startOf(argv.timeWindowType);
+  var endBase = moment().utc().endOf(argv.timeWindowType);
+  // console.log('startBase', startBase, 'endBase', endBase);
+  if (typeof argv.timeWindowValue === 'number') {
+    return [
+      startBase.subtract(argv.timeWindowValue, argv.timeWindowType),
+      endBase.add(argv.timeWindowValue, argv.timeWindowType)
+    ];
+  }
+
+  else if (typeof argv.timeWindowValue === 'string') {
+    if (customDayBoundsRE.test(argv.timeWindowValue)) {
+      var ends = argv.timeWindowValue.split('/').map(parseFloat);
+      return [
+        startBase.subtract(ends[0], argv.timeWindowType),
+        endBase.add(ends[1], argv.timeWindowType)
+      ];
+    }
+    else if (oldDayExpressionRE.test(argv.timeWindowValue)) {
+      throw new TypeError('the format of the --days flag has changed. run `makelogs --help` for more info.')
+    }
+  }
+
+  else {
+    throw new TypeError('Unable to determine the starting and end dates.');
+  }
+};

--- a/argv/index.js
+++ b/argv/index.js
@@ -8,7 +8,9 @@ program
   .name('makelogs')
   .description('A utility to generate sample log data.')
   .option('-c, --count <number>', 'Total event that will be created, accepts expressions like "1m" for 1 million (b,m,t,h)', parseNumber, 14000)
-  .requiredOption('-d, --days <number>', 'Number of days ± today to generate data for. Use one number or two separated by a slash, e.g. "1/10" to go back one day, and forward 10', parseNumber, 1)
+  // .requiredOption('-d, --days <number>', 'Number of days ± today to generate data for. Use one number or two separated by a slash, e.g. "1/10" to go back one day, and forward 10', parseNumber, 1)
+  .option('--timeWindowType <...>', 'The time window in which documents will be created, either "day", "hour", "minute"', parseTimeWindow, 'day')
+  .option('--timeWindowValue <number>', 'Number of days/hours/minutes ± now to generate data for. Use one number or two separated by a slash, e.g. "1/10" to go back one hour, and forward 10', parseNumber, 1)
   .option('--url <url>', 'Elasticsearch url, overrides host and auth, can include any url part.')
   .option('-h, --host <host>', 'The host name and port', 'localhost:9200')
   .option('--auth <auth>', 'user:password when you want to connect to a secured elasticsearch cluster over basic auth', null)
@@ -34,8 +36,8 @@ program
 
 program.parse(process.argv);
 
-// get the start and end moments
-var moments = require('./_parseDays')(program);
+// // get the start and end moments
+var moments = require('./_parseTime')(program);
 program.start = moments[0];
 program.end = moments[1];
 
@@ -69,6 +71,17 @@ function parseIndexInterval (str) {
     case 'weekly':
     case 'monthly':
     case 'yearly':
+      return str;
+    default:
+      return parseNumberStrict(str);
+  }
+}
+
+function parseTimeWindow (str) {
+  switch (str) {
+    case 'day':
+    case 'hour':
+    case 'minute':
       return str;
     default:
       return parseNumberStrict(str);

--- a/argv/index.js
+++ b/argv/index.js
@@ -10,12 +10,17 @@ program
   .option('-c, --count <number>', 'Total event that will be created, accepts expressions like "1m" for 1 million (b,m,t,h)', parseNumber, 14000)
   // .requiredOption('-d, --days <number>', 'Number of days ± today to generate data for. Use one number or two separated by a slash, e.g. "1/10" to go back one day, and forward 10', parseNumber, 1)
 <<<<<<< HEAD
+<<<<<<< HEAD
   .option('--timeWindowType <...>', 'The time window in which documents will be created, either "day", "hour", "minute"', parseTimeWindow, 'day')
   .option('--timeWindowValue <number>', 'Number of days/hours/minutes ± now to generate data for. Use one number or two separated by a slash, e.g. "1/10" to go back one hour, and forward 10', parseNumber, 1)
 =======
   .option('-d, --days <number>', 'Number of days ± today to generate data for. Use one number or two separated by a slash, e.g. "1/10" to go back one day, and forward 10', parseString, null)
   .option('-t, --time <...>', 'Number of days/hours/minutes ± today/now to generate data for. Use one number&first_letter or two separated by a slash, e.g. "1d/10h" to go back one day, and forward 10 hours', parseString, null)
 >>>>>>> v1.1
+=======
+  .option('--timeWindowType <...>', 'The time window in which documents will be created, either "day", "hour", "minute"', parseTimeWindow, 'day')
+  .option('--timeWindowValue <number>', 'Number of days/hours/minutes ± now to generate data for. Use one number or two separated by a slash, e.g. "1/10" to go back one hour, and forward 10', parseNumber, 1)
+>>>>>>> parent of 23b7c93... modify _parseTime.js to use -t param
   .option('--url <url>', 'Elasticsearch url, overrides host and auth, can include any url part.')
   .option('-h, --host <host>', 'The host name and port', 'localhost:9200')
   .option('--auth <auth>', 'user:password when you want to connect to a secured elasticsearch cluster over basic auth', null)


### PR DESCRIPTION
Hey there, 
I have modified the official `master` branch with a custom release. Basically, I modified the section related to span documents over a window time. Since I had the need to distribute documents in a smaller window time (i.e. only 10 minutes) I implemented this feature. Maybe it could be helpful also to someone else.
The command line follow the example below:

`docker run --rm makelogs --url "https://elastic:xxxx@0.0.0.0:9200"  --indexPrefix "test-" -c 300 --timeWindowType "hour" --timeWindowValue "3/2" --no-reset`

`--timeWindowType` parameter could be `day/hour/minute` (yes, declined to singular)

I haven't any particular JS experience, so I modified the code just to get my purpose avoiding any noticeable error.

